### PR TITLE
Ensure Ionic components are standalone and update specs

### DIFF
--- a/frazer-ui/src/app/app.component.ts
+++ b/frazer-ui/src/app/app.component.ts
@@ -3,6 +3,7 @@ import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
   templateUrl: 'app.component.html',
   imports: [IonApp, IonRouterOutlet],
 })

--- a/frazer-ui/src/app/explore-container/explore-container.component.spec.ts
+++ b/frazer-ui/src/app/explore-container/explore-container.component.spec.ts
@@ -7,6 +7,10 @@ describe('ExploreContainerComponent', () => {
   let fixture: ComponentFixture<ExploreContainerComponent>;
 
   beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ExploreContainerComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(ExploreContainerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/frazer-ui/src/app/explore-container/explore-container.component.ts
+++ b/frazer-ui/src/app/explore-container/explore-container.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 
 @Component({
   selector: 'app-explore-container',
+  standalone: true,
   templateUrl: './explore-container.component.html',
   styleUrls: ['./explore-container.component.scss'],
 })

--- a/frazer-ui/src/app/tab1/tab1.page.spec.ts
+++ b/frazer-ui/src/app/tab1/tab1.page.spec.ts
@@ -1,12 +1,30 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { Tab1Page } from './tab1.page';
+import { FrazerApiService } from '../services/frazer-api.service';
+import { FrazerRecord } from '../models/frazer-record';
 
 describe('Tab1Page', () => {
   let component: Tab1Page;
   let fixture: ComponentFixture<Tab1Page>;
+  let apiSpy: jasmine.SpyObj<FrazerApiService>;
 
   beforeEach(async () => {
+    apiSpy = jasmine.createSpyObj<FrazerApiService>(
+      'FrazerApiService',
+      ['getRecords', 'createRecord', 'updateRecord', 'deleteRecord']
+    );
+    apiSpy.getRecords.and.returnValue(of([]));
+    apiSpy.createRecord.and.returnValue(of({} as FrazerRecord));
+    apiSpy.updateRecord.and.returnValue(of({} as FrazerRecord));
+    apiSpy.deleteRecord.and.returnValue(of(void 0));
+
+    await TestBed.configureTestingModule({
+      imports: [Tab1Page],
+      providers: [{ provide: FrazerApiService, useValue: apiSpy }],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(Tab1Page);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/frazer-ui/src/app/tab2/tab2.page.spec.ts
+++ b/frazer-ui/src/app/tab2/tab2.page.spec.ts
@@ -7,6 +7,10 @@ describe('Tab2Page', () => {
   let fixture: ComponentFixture<Tab2Page>;
 
   beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Tab2Page],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(Tab2Page);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/frazer-ui/src/app/tab2/tab2.page.ts
+++ b/frazer-ui/src/app/tab2/tab2.page.ts
@@ -4,9 +4,10 @@ import { ExploreContainerComponent } from '../explore-container/explore-containe
 
 @Component({
   selector: 'app-tab2',
+  standalone: true,
   templateUrl: 'tab2.page.html',
   styleUrls: ['tab2.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent, ExploreContainerComponent]
+  imports: [IonHeader, IonToolbar, IonTitle, IonContent, ExploreContainerComponent],
 })
 export class Tab2Page {
 

--- a/frazer-ui/src/app/tab3/tab3.page.spec.ts
+++ b/frazer-ui/src/app/tab3/tab3.page.spec.ts
@@ -7,6 +7,10 @@ describe('Tab3Page', () => {
   let fixture: ComponentFixture<Tab3Page>;
 
   beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Tab3Page],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(Tab3Page);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/frazer-ui/src/app/tab3/tab3.page.ts
+++ b/frazer-ui/src/app/tab3/tab3.page.ts
@@ -4,6 +4,7 @@ import { ExploreContainerComponent } from '../explore-container/explore-containe
 
 @Component({
   selector: 'app-tab3',
+  standalone: true,
   templateUrl: 'tab3.page.html',
   styleUrls: ['tab3.page.scss'],
   imports: [IonHeader, IonToolbar, IonTitle, IonContent, ExploreContainerComponent],

--- a/frazer-ui/src/app/tabs/tabs.page.ts
+++ b/frazer-ui/src/app/tabs/tabs.page.ts
@@ -5,6 +5,7 @@ import { triangle, ellipse, square } from 'ionicons/icons';
 
 @Component({
   selector: 'app-tabs',
+  standalone: true,
   templateUrl: 'tabs.page.html',
   styleUrls: ['tabs.page.scss'],
   imports: [IonTabs, IonTabBar, IonTabButton, IonIcon, IonLabel],


### PR DESCRIPTION
## Summary
- mark the root app, tabs, and placeholder tab components as standalone so they can be lazy loaded
- make the shared explore container standalone for reuse in tab routes
- update tab specs to configure TestBed properly and stub Frazer API dependencies

## Testing
- npm run lint *(fails: angular-eslint prefer-inject violations in existing services)*

------
https://chatgpt.com/codex/tasks/task_b_68e56019c0bc833196badb4a95d11892