### PR TITLE
Fix package downgrades and result accessibility

### DIFF
--- a/frazer-api/src/Api/Api.csproj
+++ b/frazer-api/src/Api/Api.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/frazer-api/src/Application/Common/Result.cs
+++ b/frazer-api/src/Application/Common/Result.cs
@@ -2,7 +2,7 @@ namespace FrazerDealer.Application.Common;
 
 public class Result
 {
-    private Result(bool succeeded, IEnumerable<string>? errors = null)
+    protected Result(bool succeeded, IEnumerable<string>? errors = null)
     {
         Succeeded = succeeded;
         Errors = errors?.ToArray() ?? Array.Empty<string>();

--- a/frazer-api/src/Infrastructure/Infrastructure.csproj
+++ b/frazer-api/src/Infrastructure/Infrastructure.csproj
@@ -23,10 +23,10 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- update Microsoft.Extensions packages to version 9.0.0 to align with dependency requirements
- expose the base Result constructor to derived types to resolve accessibility errors

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e8b5a21e6c83318ace0c093be8e964