### PR TITLE
Add missing health check package reference

### DIFF
--- a/frazer-api/src/Infrastructure/Infrastructure.csproj
+++ b/frazer-api/src/Infrastructure/Infrastructure.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />


### PR DESCRIPTION
## Summary
- add the Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore package so AddDbContextCheck is available

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68e8b6af9e848331a7db854e7a27830d