### PR TITLE
Add runtime instrumentation package

### DIFF
--- a/frazer-api/src/Api/Program.cs
+++ b/frazer-api/src/Api/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Instrumentation.Runtime;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;

--- a/frazer-api/src/Infrastructure/Infrastructure.csproj
+++ b/frazer-api/src/Infrastructure/Infrastructure.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.0" />


### PR DESCRIPTION
## Summary
- add the OpenTelemetry runtime instrumentation package to the infrastructure project
- import the runtime instrumentation namespace in Program.cs so the extension method resolves

## Testing
- `dotnet build FrazerDealer.sln` *(fails: `dotnet` CLI unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e8b76954cc83319ded0053f7b1803e