### PR TITLE
Fix Hangfire memory storage configuration

### DIFF
--- a/frazer-api/src/Infrastructure/DependencyInjection.cs
+++ b/frazer-api/src/Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using FrazerDealer.Application.Interfaces;
 using FrazerDealer.Application.Interfaces.Adapters;
 using FrazerDealer.Application.Jobs;

--- a/frazer-api/src/Infrastructure/Infrastructure.csproj
+++ b/frazer-api/src/Infrastructure/Infrastructure.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Hangfire.Core" Version="1.8.11" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.11" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
-    <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.2" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.2" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />


### PR DESCRIPTION
## Summary
- update Hangfire.MemoryStorage package reference to the latest available version on NuGet
- add the missing SocketException import required by the Hangfire connectivity fallback

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68eab1493b948331bbc09a757fce463b