### PR TITLE
Switch backend services to SQL Server

### DIFF
--- a/frazer-api/docker-compose.yml
+++ b/frazer-api/docker-compose.yml
@@ -1,25 +1,25 @@
 version: '3.9'
 services:
-  postgres:
-    image: postgres:16
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
-      POSTGRES_DB: frazer_dev
-      POSTGRES_USER: frazer
-      POSTGRES_PASSWORD: frazer
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: Your_password123
+      MSSQL_PID: "Express"
     ports:
-      - "5432:5432"
+      - "1433:1433"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - sqlserver_data:/var/opt/mssql
   api:
     build:
       context: .
       dockerfile: ./src/Api/Dockerfile
     environment:
       ASPNETCORE_ENVIRONMENT: Development
-      ConnectionStrings__Default: Host=postgres;Port=5432;Database=frazer_dev;Username=frazer;Password=frazer
+      ConnectionStrings__Default: Server=sqlserver,1433;Database=frazer_dev;User Id=sa;Password=Your_password123;TrustServerCertificate=True;Encrypt=False
     depends_on:
-      - postgres
+      - sqlserver
     ports:
       - "8080:8080"
 volumes:
-  postgres_data:
+  sqlserver_data:

--- a/frazer-api/src/Api/appsettings.Development.json
+++ b/frazer-api/src/Api/appsettings.Development.json
@@ -7,7 +7,7 @@
     }
   },
   "ConnectionStrings": {
-    "Default": "Host=postgres;Port=5432;Database=frazer_dev;Username=frazer;Password=frazer"
+    "Default": "Server=sqlserver,1433;Database=frazer_dev;User Id=sa;Password=Your_password123;TrustServerCertificate=True;Encrypt=False"
   },
   "Jwt": {
     "Issuer": "frazer-dev",

--- a/frazer-api/src/Api/appsettings.json
+++ b/frazer-api/src/Api/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Default": "Host=localhost;Port=5432;Database=frazer_dev;Username=frazer;Password=frazer"
+    "Default": "Server=localhost,1433;Database=frazer_dev;User Id=sa;Password=Your_password123;TrustServerCertificate=True;Encrypt=False"
   },
   "Jwt": {
     "Issuer": "frazer",

--- a/frazer-api/src/Infrastructure/Infrastructure.csproj
+++ b/frazer-api/src/Infrastructure/Infrastructure.csproj
@@ -12,10 +12,11 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3" PrivateAssets="all" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Hangfire.Core" Version="1.8.11" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.11" />
-    <PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.11" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.2" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />


### PR DESCRIPTION
## Summary
- replace PostgreSQL dependencies and configuration with SQL Server equivalents in the infrastructure layer
- update default application settings and docker-compose environment to target SQL Server connection strings

## Testing
- `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68eab542121c83319d6217faa586186b