### PR TITLE
Add initial EF Core migration and configure context

### DIFF
--- a/frazer-api/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/frazer-api/src/Infrastructure/Persistence/AppDbContext.cs
@@ -21,6 +21,79 @@ public class AppDbContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Vehicle>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.HasOne(e => e.CurrentSale)
+                .WithMany()
+                .HasForeignKey(e => e.CurrentSaleId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        modelBuilder.Entity<Customer>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+        });
+
+        modelBuilder.Entity<Sale>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.Ignore(e => e.BalanceDue);
+
+            entity.HasOne(e => e.Vehicle)
+                .WithMany(e => e.SalesHistory)
+                .HasForeignKey(e => e.VehicleId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(e => e.Customer)
+                .WithMany(e => e.Sales)
+                .HasForeignKey(e => e.CustomerId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<Fee>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.HasOne(e => e.Sale)
+                .WithMany(e => e.Fees)
+                .HasForeignKey(e => e.SaleId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Payment>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.HasOne(e => e.Sale)
+                .WithMany(e => e.Payments)
+                .HasForeignKey(e => e.SaleId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<InsuranceProvider>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+        });
+
+        modelBuilder.Entity<RecurringJob>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+        });
+
+        modelBuilder.Entity<JobLog>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.HasOne(e => e.RecurringJob)
+                .WithMany()
+                .HasForeignKey(e => e.RecurringJobId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
     }
 }

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/20240419120000_InitialCreate.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/20240419120000_InitialCreate.cs
@@ -1,0 +1,253 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FrazerDealer.Infrastructure.Persistence.Migrations;
+
+public partial class InitialCreate : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Customers",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                FirstName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                LastName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Phone = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Address = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                City = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                State = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                PostalCode = table.Column<string>(type: "nvarchar(max)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Customers", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "InsuranceProviders",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Phone = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Notes = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_InsuranceProviders", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "RecurringJobs",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                CronExpression = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                LastRun = table.Column<DateTime>(type: "datetime2", nullable: true),
+                IsActive = table.Column<bool>(type: "bit", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_RecurringJobs", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Vehicles",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Vin = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                StockNumber = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Year = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Make = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Model = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Trim = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Price = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                Cost = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                IsSold = table.Column<bool>(type: "bit", nullable: false),
+                DateArrived = table.Column<DateTime>(type: "datetime2", nullable: true),
+                DateSold = table.Column<DateTime>(type: "datetime2", nullable: true),
+                CurrentSaleId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Vehicles", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "JobLogs",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                RecurringJobId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                StartedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CompletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                WasSuccessful = table.Column<bool>(type: "bit", nullable: false),
+                Message = table.Column<string>(type: "nvarchar(max)", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_JobLogs", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_JobLogs_RecurringJobs_RecurringJobId",
+                    column: x => x.RecurringJobId,
+                    principalTable: "RecurringJobs",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Sales",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                VehicleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                CustomerId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Status = table.Column<int>(type: "int", nullable: false),
+                CreatedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                CompletedOn = table.Column<DateTime>(type: "datetime2", nullable: true),
+                Subtotal = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                FeesTotal = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                PaymentsTotal = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Sales", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Sales_Customers_CustomerId",
+                    column: x => x.CustomerId,
+                    principalTable: "Customers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_Sales_Vehicles_VehicleId",
+                    column: x => x.VehicleId,
+                    principalTable: "Vehicles",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Fees",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                SaleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Code = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Description = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                IsRecurring = table.Column<bool>(type: "bit", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Fees", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Fees_Sales_SaleId",
+                    column: x => x.SaleId,
+                    principalTable: "Sales",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Payments",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                SaleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                CollectedOn = table.Column<DateTime>(type: "datetime2", nullable: false),
+                Method = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Status = table.Column<int>(type: "int", nullable: false),
+                ExternalReference = table.Column<string>(type: "nvarchar(max)", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Payments", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Payments_Sales_SaleId",
+                    column: x => x.SaleId,
+                    principalTable: "Sales",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Fees_SaleId",
+            table: "Fees",
+            column: "SaleId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_JobLogs_RecurringJobId",
+            table: "JobLogs",
+            column: "RecurringJobId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Payments_SaleId",
+            table: "Payments",
+            column: "SaleId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Sales_CustomerId",
+            table: "Sales",
+            column: "CustomerId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Sales_VehicleId",
+            table: "Sales",
+            column: "VehicleId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Vehicles_CurrentSaleId",
+            table: "Vehicles",
+            column: "CurrentSaleId");
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_Vehicles_Sales_CurrentSaleId",
+            table: "Vehicles",
+            column: "CurrentSaleId",
+            principalTable: "Sales",
+            principalColumn: "Id",
+            onDelete: ReferentialAction.SetNull);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_Vehicles_Sales_CurrentSaleId",
+            table: "Vehicles");
+
+        migrationBuilder.DropTable(
+            name: "Fees");
+
+        migrationBuilder.DropTable(
+            name: "InsuranceProviders");
+
+        migrationBuilder.DropTable(
+            name: "JobLogs");
+
+        migrationBuilder.DropTable(
+            name: "Payments");
+
+        migrationBuilder.DropTable(
+            name: "RecurringJobs");
+
+        migrationBuilder.DropTable(
+            name: "Sales");
+
+        migrationBuilder.DropTable(
+            name: "Customers");
+
+        migrationBuilder.DropTable(
+            name: "Vehicles");
+    }
+}

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -1,0 +1,389 @@
+using System;
+using FrazerDealer.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
+
+namespace FrazerDealer.Infrastructure.Persistence.Migrations;
+
+[DbContext(typeof(AppDbContext))]
+partial class AppDbContextModelSnapshot : ModelSnapshot
+{
+    protected override void BuildModel(ModelBuilder modelBuilder)
+    {
+#pragma warning disable 612, 618
+        modelBuilder
+            .HasAnnotation("ProductVersion", "8.0.3")
+            .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+        SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Customer", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("Address")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("City")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Email")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("FirstName")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("LastName")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Phone")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("PostalCode")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("State")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.ToTable("Customers");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Fee", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("Code")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Description")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<bool>("IsRecurring")
+                .HasColumnType("bit");
+
+            b.Property<Guid>("SaleId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<decimal>("Amount")
+                .HasColumnType("decimal(18,2)");
+
+            b.HasKey("Id");
+
+            b.HasIndex("SaleId");
+
+            b.ToTable("Fees");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.InsuranceProvider", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("Email")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Notes")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Phone")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.ToTable("InsuranceProviders");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.JobLog", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("CompletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Message")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<Guid>("RecurringJobId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime>("StartedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<bool>("WasSuccessful")
+                .HasColumnType("bit");
+
+            b.HasKey("Id");
+
+            b.HasIndex("RecurringJobId");
+
+            b.ToTable("JobLogs");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Payment", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<decimal>("Amount")
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<DateTime>("CollectedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("ExternalReference")
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Method")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<Guid>("SaleId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<int>("Status")
+                .HasColumnType("int");
+
+            b.HasKey("Id");
+
+            b.HasIndex("SaleId");
+
+            b.ToTable("Payments");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.RecurringJob", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("CronExpression")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<bool>("IsActive")
+                .HasColumnType("bit");
+
+            b.Property<DateTime?>("LastRun")
+                .HasColumnType("datetime2");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.ToTable("RecurringJobs");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Sale", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("CompletedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<Guid>("CustomerId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<decimal>("FeesTotal")
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<decimal>("PaymentsTotal")
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<DateTime>("CreatedOn")
+                .HasColumnType("datetime2");
+
+            b.Property<int>("Status")
+                .HasColumnType("int");
+
+            b.Property<decimal>("Subtotal")
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<Guid>("VehicleId")
+                .HasColumnType("uniqueidentifier");
+
+            b.HasKey("Id");
+
+            b.HasIndex("CustomerId");
+
+            b.HasIndex("VehicleId");
+
+            b.ToTable("Sales");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Vehicle", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<decimal>("Cost")
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<Guid?>("CurrentSaleId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<DateTime?>("DateArrived")
+                .HasColumnType("datetime2");
+
+            b.Property<DateTime?>("DateSold")
+                .HasColumnType("datetime2");
+
+            b.Property<bool>("IsSold")
+                .HasColumnType("bit");
+
+            b.Property<string>("Make")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Model")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<decimal>("Price")
+                .HasColumnType("decimal(18,2)");
+
+            b.Property<string>("StockNumber")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Trim")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Vin")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Year")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.HasIndex("CurrentSaleId");
+
+            b.ToTable("Vehicles");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Fee", b =>
+        {
+            b.HasOne("FrazerDealer.Domain.Entities.Sale", "Sale")
+                .WithMany("Fees")
+                .HasForeignKey("SaleId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.Navigation("Sale");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.JobLog", b =>
+        {
+            b.HasOne("FrazerDealer.Domain.Entities.RecurringJob", "RecurringJob")
+                .WithMany()
+                .HasForeignKey("RecurringJobId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.Navigation("RecurringJob");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Payment", b =>
+        {
+            b.HasOne("FrazerDealer.Domain.Entities.Sale", "Sale")
+                .WithMany("Payments")
+                .HasForeignKey("SaleId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.Navigation("Sale");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Sale", b =>
+        {
+            b.HasOne("FrazerDealer.Domain.Entities.Customer", "Customer")
+                .WithMany("Sales")
+                .HasForeignKey("CustomerId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.HasOne("FrazerDealer.Domain.Entities.Vehicle", "Vehicle")
+                .WithMany("SalesHistory")
+                .HasForeignKey("VehicleId")
+                .OnDelete(DeleteBehavior.Restrict)
+                .IsRequired();
+
+            b.Navigation("Customer");
+
+            b.Navigation("Vehicle");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Vehicle", b =>
+        {
+            b.HasOne("FrazerDealer.Domain.Entities.Sale", "CurrentSale")
+                .WithMany()
+                .HasForeignKey("CurrentSaleId")
+                .OnDelete(DeleteBehavior.SetNull);
+
+            b.Navigation("CurrentSale");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Customer", b =>
+        {
+            b.Navigation("Sales");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Sale", b =>
+        {
+            b.Navigation("Fees");
+
+            b.Navigation("Payments");
+        });
+
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Vehicle", b =>
+        {
+            b.Navigation("SalesHistory");
+        });
+#pragma warning restore 612, 618
+    }
+}


### PR DESCRIPTION
## Summary
- configure the EF Core model so entity relationships and the computed balance property map cleanly
- add the initial EF Core migration that builds tables for the current domain aggregate set

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68eac063db388331aeed3ef9999c2ba5