### PR TITLE
Align initial migration with vehicle configuration

### DIFF
--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -14,6 +14,9 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
         builder.Property(v => v.Make).HasMaxLength(128);
         builder.Property(v => v.Model).HasMaxLength(128);
         builder.Property(v => v.Trim).HasMaxLength(128);
+        builder.Property(v => v.Year).HasMaxLength(4);
+        builder.Property(v => v.Price).HasColumnType("decimal(18,2)");
+        builder.Property(v => v.Cost).HasColumnType("decimal(18,2)");
 
         builder.HasMany(v => v.SalesHistory)
             .WithOne(s => s.Vehicle)

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/20240419120000_InitialCreate.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/20240419120000_InitialCreate.cs
@@ -1,10 +1,14 @@
 using System;
+using FrazerDealer.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace FrazerDealer.Infrastructure.Persistence.Migrations;
 
+[DbContext(typeof(AppDbContext))]
+[Migration("20240419120000_InitialCreate")]
 public partial class InitialCreate : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)
@@ -65,12 +69,12 @@ public partial class InitialCreate : Migration
             columns: table => new
             {
                 Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                Vin = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                StockNumber = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                Year = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                Make = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                Model = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                Trim = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Vin = table.Column<string>(type: "nvarchar(17)", maxLength: 17, nullable: false),
+                StockNumber = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                Year = table.Column<string>(type: "nvarchar(4)", maxLength: 4, nullable: false),
+                Make = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                Model = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                Trim = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
                 Price = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
                 Cost = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
                 IsSold = table.Column<bool>(type: "bit", nullable: false),
@@ -222,32 +226,20 @@ public partial class InitialCreate : Migration
 
     protected override void Down(MigrationBuilder migrationBuilder)
     {
-        migrationBuilder.DropForeignKey(
-            name: "FK_Vehicles_Sales_CurrentSaleId",
-            table: "Vehicles");
+        migrationBuilder.Sql("""
+            IF EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'FK_Vehicles_Sales_CurrentSaleId')
+            BEGIN
+                ALTER TABLE [Vehicles] DROP CONSTRAINT [FK_Vehicles_Sales_CurrentSaleId];
+            END
+        """);
 
-        migrationBuilder.DropTable(
-            name: "Fees");
-
-        migrationBuilder.DropTable(
-            name: "InsuranceProviders");
-
-        migrationBuilder.DropTable(
-            name: "JobLogs");
-
-        migrationBuilder.DropTable(
-            name: "Payments");
-
-        migrationBuilder.DropTable(
-            name: "RecurringJobs");
-
-        migrationBuilder.DropTable(
-            name: "Sales");
-
-        migrationBuilder.DropTable(
-            name: "Customers");
-
-        migrationBuilder.DropTable(
-            name: "Vehicles");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [Fees];");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [InsuranceProviders];");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [JobLogs];");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [Payments];");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [RecurringJobs];");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [Sales];");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [Customers];");
+        migrationBuilder.Sql("DROP TABLE IF EXISTS [Vehicles];");
     }
 }

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -274,30 +274,36 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
             b.Property<string>("Make")
                 .IsRequired()
-                .HasColumnType("nvarchar(max)");
+                .HasMaxLength(128)
+                .HasColumnType("nvarchar(128)");
 
             b.Property<string>("Model")
                 .IsRequired()
-                .HasColumnType("nvarchar(max)");
+                .HasMaxLength(128)
+                .HasColumnType("nvarchar(128)");
 
             b.Property<decimal>("Price")
                 .HasColumnType("decimal(18,2)");
 
             b.Property<string>("StockNumber")
                 .IsRequired()
-                .HasColumnType("nvarchar(max)");
+                .HasMaxLength(64)
+                .HasColumnType("nvarchar(64)");
 
             b.Property<string>("Trim")
                 .IsRequired()
-                .HasColumnType("nvarchar(max)");
+                .HasMaxLength(128)
+                .HasColumnType("nvarchar(128)");
 
             b.Property<string>("Vin")
                 .IsRequired()
-                .HasColumnType("nvarchar(max)");
+                .HasMaxLength(17)
+                .HasColumnType("nvarchar(17)");
 
             b.Property<string>("Year")
                 .IsRequired()
-                .HasColumnType("nvarchar(max)");
+                .HasMaxLength(4)
+                .HasColumnType("nvarchar(4)");
 
             b.HasKey("Id");
 


### PR DESCRIPTION
## Summary
- annotate the initial migration with its DbContext and identifier metadata so EF picks up the correct migration id
- align the Vehicles table definition in the initial migration with the model configuration, including length and precision constraints
- update the Vehicle entity configuration and snapshot to enforce VIN length, year length, and decimal precision consistently

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68eac32d444c8331a492a87416a386b7