### PR TITLE
Serve Swagger UI as default landing page

### DIFF
--- a/frazer-api/src/Api/Program.cs
+++ b/frazer-api/src/Api/Program.cs
@@ -90,11 +90,12 @@ builder.Services.AddAuthorization(options =>
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
+app.UseSwagger();
+app.UseSwaggerUI(options =>
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "FrazerDealer API v1");
+    options.RoutePrefix = string.Empty;
+});
 
 app.UseSerilogRequestLogging();
 


### PR DESCRIPTION
## Summary
- always enable Swagger middleware and expose the UI at the application root so launching the API opens the OpenAPI page

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68ead5be5f348331b6cdbcb8f571bb30