### PR TITLE
Configure API CORS policy from configuration

### DIFF
--- a/frazer-api/src/Api/Program.cs
+++ b/frazer-api/src/Api/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using FrazerDealer.Application;
 using FrazerDealer.Application.Jobs;
@@ -60,11 +61,29 @@ builder.Services.AddOpenTelemetry()
         .AddAspNetCoreInstrumentation()
         .AddRuntimeInstrumentation());
 
+var allowedOrigins = builder.Configuration
+    .GetSection("Cors:AllowedOrigins")
+    .Get<string[]>() ?? Array.Empty<string>();
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("default", policy =>
     {
-        policy.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
+        if (allowedOrigins.Length > 0)
+        {
+            policy
+                .WithOrigins(allowedOrigins)
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        }
+        else
+        {
+            policy
+                .AllowAnyOrigin()
+                .AllowAnyHeader()
+                .AllowAnyMethod();
+        }
     });
 });
 

--- a/frazer-api/src/Api/appsettings.Development.json
+++ b/frazer-api/src/Api/appsettings.Development.json
@@ -14,6 +14,12 @@
     "Audience": "frazer-dev-clients",
     "SigningKey": "local-development-signing-key"
   },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:8100",
+      "https://localhost:8100"
+    ]
+  },
   "Adapters": {
     "FrazerHub": {
       "BaseUrl": "https://frazerhub.dev"

--- a/frazer-api/src/Api/appsettings.json
+++ b/frazer-api/src/Api/appsettings.json
@@ -14,6 +14,12 @@
     "Audience": "frazer-clients",
     "SigningKey": "change-me-signing-key"
   },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:8100",
+      "https://localhost:8100"
+    ]
+  },
   "Adapters": {
     "FrazerHub": {
       "BaseUrl": "https://frazerhub.local"


### PR DESCRIPTION
## Summary
- read the API CORS allowed origins from configuration so it can return explicit origins and credentials when needed
- seed localhost Ionic origins in the default and development appsettings for smoother local testing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68ead7a1f3008331a0821e2a80ca0ed1