### PR TITLE
Update dealer UI branding to Jackson's Dealer Suite

### DIFF
--- a/frazer-ui/src/app/auth/login.page.html
+++ b/frazer-ui/src/app/auth/login.page.html
@@ -2,7 +2,7 @@
   <div class="login-card">
     <ion-header>
       <ion-toolbar color="primary">
-        <ion-title>Frazer Dealer Portal</ion-title>
+        <ion-title>Jackson's Dealer Suite Portal</ion-title>
       </ion-toolbar>
     </ion-header>
 

--- a/frazer-ui/src/app/shell/main-layout.component.html
+++ b/frazer-ui/src/app/shell/main-layout.component.html
@@ -3,7 +3,7 @@
     <ion-menu content-id="main" type="overlay">
       <ion-header>
         <ion-toolbar color="primary">
-          <ion-title>Frazer Dealer</ion-title>
+          <ion-title>Jackson's Dealer Suite</ion-title>
         </ion-toolbar>
       </ion-header>
       <ion-content>
@@ -24,7 +24,7 @@
           <ion-buttons slot="start">
             <ion-menu-button></ion-menu-button>
           </ion-buttons>
-          <ion-title>Frazer Dealer Console</ion-title>
+          <ion-title>Jackson's Dealer Suite Console</ion-title>
           <ion-buttons slot="end">
             <ion-button fill="clear" (click)="logout()">Sign out</ion-button>
           </ion-buttons>


### PR DESCRIPTION
## Summary
- replace Frazer Dealer titles in the main layout and login page with Jackson's Dealer Suite branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68eade2cc8808331ae29efccdab8dc52