### PR TITLE
Configure Swagger document for API

### DIFF
--- a/frazer-api/src/Api/Program.cs
+++ b/frazer-api/src/Api/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using OpenTelemetry.Instrumentation.Runtime;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -50,7 +51,14 @@ var jwtSettings = builder.Configuration
     .Get<JwtOptions>() ?? new JwtOptions();
 
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+    {
+        Title = "FrazerDealer API",
+        Version = "v1"
+    });
+});
 
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(resource => resource.AddService("FrazerDealer.Api"))


### PR DESCRIPTION
## Summary
- configure the Swagger generator with a v1 document so the UI can load successfully

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_b_68eae38a52e083318ce3ccdb8c2eacf6