### PR TITLE
Add prospects management entities and UI

### DIFF
--- a/frazer-api/src/Api/Controllers/ProspectsController.cs
+++ b/frazer-api/src/Api/Controllers/ProspectsController.cs
@@ -1,0 +1,61 @@
+using FrazerDealer.Application.Interfaces;
+using FrazerDealer.Contracts.Prospects;
+using FrazerDealer.Infrastructure.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FrazerDealer.Api.Controllers;
+
+[ApiController]
+[Route("api/prospects")]
+[Authorize]
+public class ProspectsController : ControllerBase
+{
+    private readonly IProspectService _prospectService;
+
+    public ProspectsController(IProspectService prospectService)
+    {
+        _prospectService = prospectService;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(IEnumerable<ProspectSummary>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetProspects(CancellationToken cancellationToken)
+    {
+        var result = await _prospectService.GetProspectsAsync(cancellationToken);
+        if (!result.Succeeded || result.Value is null)
+        {
+            return Problem(detail: string.Join(';', result.Errors));
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(ProspectSummary), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetProspect(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await _prospectService.GetProspectAsync(id, cancellationToken);
+        if (!result.Succeeded || result.Value is null)
+        {
+            return NotFound(result.Errors);
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPost]
+    [Authorize(Roles = Roles.Admin + "," + Roles.Manager + "," + Roles.Sales)]
+    [ProducesResponseType(typeof(ProspectSummary), StatusCodes.Status201Created)]
+    public async Task<IActionResult> CreateProspect([FromBody] CreateProspectRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _prospectService.CreateProspectAsync(request, cancellationToken);
+        if (!result.Succeeded || result.Value is null)
+        {
+            return BadRequest(result.Errors);
+        }
+
+        return CreatedAtAction(nameof(GetProspect), new { id = result.Value.Id }, result.Value);
+    }
+}

--- a/frazer-api/src/Application/Interfaces/IProspectService.cs
+++ b/frazer-api/src/Application/Interfaces/IProspectService.cs
@@ -1,0 +1,11 @@
+using FrazerDealer.Application.Common;
+using FrazerDealer.Contracts.Prospects;
+
+namespace FrazerDealer.Application.Interfaces;
+
+public interface IProspectService
+{
+    Task<Result<IReadOnlyCollection<ProspectSummary>>> GetProspectsAsync(CancellationToken cancellationToken);
+    Task<Result<ProspectSummary>> GetProspectAsync(Guid id, CancellationToken cancellationToken);
+    Task<Result<ProspectSummary>> CreateProspectAsync(CreateProspectRequest request, CancellationToken cancellationToken);
+}

--- a/frazer-api/src/Contracts/Prospects/ProspectDtos.cs
+++ b/frazer-api/src/Contracts/Prospects/ProspectDtos.cs
@@ -1,0 +1,16 @@
+namespace FrazerDealer.Contracts.Prospects;
+
+public record ProspectVehicleSummary(Guid Id, string StockNumber, string Year, string Make, string Model);
+
+public record ProspectSummary(
+    Guid Id,
+    string Name,
+    string Email,
+    string Phone,
+    IReadOnlyCollection<ProspectVehicleSummary> Vehicles);
+
+public record CreateProspectRequest(
+    string Name,
+    string Email,
+    string Phone,
+    IReadOnlyCollection<Guid> VehicleIds);

--- a/frazer-api/src/Domain/Entities/Prospect.cs
+++ b/frazer-api/src/Domain/Entities/Prospect.cs
@@ -1,0 +1,11 @@
+namespace FrazerDealer.Domain.Entities;
+
+public class Prospect
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string Phone { get; set; } = string.Empty;
+
+    public List<Vehicle> Vehicles { get; set; } = new();
+}

--- a/frazer-api/src/Domain/Entities/Vehicle.cs
+++ b/frazer-api/src/Domain/Entities/Vehicle.cs
@@ -17,4 +17,5 @@ public class Vehicle
     public Guid? CurrentSaleId { get; set; }
     public Sale? CurrentSale { get; set; }
     public List<Sale> SalesHistory { get; set; } = new();
+    public List<Prospect> Prospects { get; set; } = new();
 }

--- a/frazer-api/src/Infrastructure/DependencyInjection.cs
+++ b/frazer-api/src/Infrastructure/DependencyInjection.cs
@@ -57,6 +57,7 @@ public static class DependencyInjection
         services.AddScoped<IAuthService, FakeAuthService>();
         services.AddScoped<IVehicleService, FakeVehicleService>();
         services.AddScoped<ICustomerService, FakeCustomerService>();
+        services.AddScoped<IProspectService, FakeProspectService>();
         services.AddScoped<ISaleService, FakeSaleService>();
         services.AddScoped<IFeeService, FakeFeeService>();
         services.AddScoped<IInsuranceService, FakeInsuranceService>();

--- a/frazer-api/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/frazer-api/src/Infrastructure/Persistence/AppDbContext.cs
@@ -11,6 +11,7 @@ public class AppDbContext : DbContext
 
     public DbSet<Vehicle> Vehicles => Set<Vehicle>();
     public DbSet<Customer> Customers => Set<Customer>();
+    public DbSet<Prospect> Prospects => Set<Prospect>();
     public DbSet<Sale> Sales => Set<Sale>();
     public DbSet<Fee> Fees => Set<Fee>();
     public DbSet<Payment> Payments => Set<Payment>();
@@ -35,6 +36,15 @@ public class AppDbContext : DbContext
         modelBuilder.Entity<Customer>(entity =>
         {
             entity.HasKey(e => e.Id);
+        });
+
+        modelBuilder.Entity<Prospect>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.HasMany(e => e.Vehicles)
+                .WithMany(e => e.Prospects)
+                .UsingEntity(j => j.ToTable("ProspectVehicle"));
         });
 
         modelBuilder.Entity<Sale>(entity =>

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/20240501000000_AddProspects.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/20240501000000_AddProspects.cs
@@ -1,0 +1,64 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FrazerDealer.Infrastructure.Persistence.Migrations;
+
+public partial class AddProspects : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Prospects",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Email = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                Phone = table.Column<string>(type: "nvarchar(max)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Prospects", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "ProspectVehicle",
+            columns: table => new
+            {
+                ProspectsId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                VehiclesId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ProspectVehicle", x => new { x.ProspectsId, x.VehiclesId });
+                table.ForeignKey(
+                    name: "FK_ProspectVehicle_Prospects_ProspectsId",
+                    column: x => x.ProspectsId,
+                    principalTable: "Prospects",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_ProspectVehicle_Vehicles_VehiclesId",
+                    column: x => x.VehiclesId,
+                    principalTable: "Vehicles",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ProspectVehicle_VehiclesId",
+            table: "ProspectVehicle",
+            column: "VehiclesId");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "ProspectVehicle");
+
+        migrationBuilder.DropTable(
+            name: "Prospects");
+    }
+}

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -184,6 +184,29 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.ToTable("Payments");
         });
 
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.Prospect", b =>
+        {
+            b.Property<Guid>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<string>("Email")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Name")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.Property<string>("Phone")
+                .IsRequired()
+                .HasColumnType("nvarchar(max)");
+
+            b.HasKey("Id");
+
+            b.ToTable("Prospects");
+        });
+
         modelBuilder.Entity("FrazerDealer.Domain.Entities.RecurringJob", b =>
         {
             b.Property<Guid>("Id")
@@ -312,6 +335,21 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.ToTable("Vehicles");
         });
 
+        modelBuilder.Entity("ProspectVehicle", b =>
+        {
+            b.Property<Guid>("ProspectsId")
+                .HasColumnType("uniqueidentifier");
+
+            b.Property<Guid>("VehiclesId")
+                .HasColumnType("uniqueidentifier");
+
+            b.HasKey("ProspectsId", "VehiclesId");
+
+            b.HasIndex("VehiclesId");
+
+            b.ToTable("ProspectVehicle", (string)null);
+        });
+
         modelBuilder.Entity("FrazerDealer.Domain.Entities.Fee", b =>
         {
             b.HasOne("FrazerDealer.Domain.Entities.Sale", "Sale")
@@ -374,6 +412,21 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.Navigation("CurrentSale");
         });
 
+        modelBuilder.Entity("ProspectVehicle", b =>
+        {
+            b.HasOne("FrazerDealer.Domain.Entities.Prospect", null)
+                .WithMany()
+                .HasForeignKey("ProspectsId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.HasOne("FrazerDealer.Domain.Entities.Vehicle", null)
+                .WithMany()
+                .HasForeignKey("VehiclesId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+        });
+
         modelBuilder.Entity("FrazerDealer.Domain.Entities.Customer", b =>
         {
             b.Navigation("Sales");
@@ -388,6 +441,8 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
         modelBuilder.Entity("FrazerDealer.Domain.Entities.Vehicle", b =>
         {
+            b.Navigation("Prospects");
+
             b.Navigation("SalesHistory");
         });
 #pragma warning restore 612, 618

--- a/frazer-api/src/Infrastructure/Persistence/Seed/SeedData.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Seed/SeedData.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using FrazerDealer.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -99,6 +100,37 @@ public static class SeedData
                     Notes = "Preferred gap coverage"
                 }
             }, cancellationToken);
+        }
+
+        if (!await context.Prospects.AnyAsync(cancellationToken))
+        {
+            var availableVehicles = context.Vehicles.Local.ToList();
+            if (availableVehicles.Count == 0)
+            {
+                availableVehicles = await context.Vehicles.ToListAsync(cancellationToken);
+            }
+
+            var prospects = new List<Prospect>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Alex Johnson",
+                    Email = "alex.johnson@example.com",
+                    Phone = "555-0400",
+                    Vehicles = availableVehicles.Take(1).ToList()
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "Riley Chen",
+                    Email = "riley.chen@example.com",
+                    Phone = "555-0500",
+                    Vehicles = availableVehicles.Skip(1).Take(1).ToList()
+                }
+            };
+
+            await context.Prospects.AddRangeAsync(prospects, cancellationToken);
         }
 
         await context.SaveChangesAsync(cancellationToken);

--- a/frazer-ui/src/app/customers/customers.page.html
+++ b/frazer-ui/src/app/customers/customers.page.html
@@ -1,0 +1,17 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Customers</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-list>
+    <ion-item *ngFor="let customer of customers$ | async">
+      <ion-label>
+        <h2>{{ customer.firstName }} {{ customer.lastName }}</h2>
+        <p>{{ customer.email }}</p>
+        <p>{{ customer.phone }}</p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/frazer-ui/src/app/customers/customers.page.scss
+++ b/frazer-ui/src/app/customers/customers.page.scss
@@ -1,0 +1,3 @@
+ion-item {
+  --padding-start: 0;
+}

--- a/frazer-ui/src/app/customers/customers.page.ts
+++ b/frazer-ui/src/app/customers/customers.page.ts
@@ -1,0 +1,24 @@
+import { AsyncPipe, NgFor } from '@angular/common';
+import { Component } from '@angular/core';
+import {
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
+import { provideFixtures } from '../data/fixtures';
+
+@Component({
+  selector: 'app-customers',
+  standalone: true,
+  imports: [IonContent, IonHeader, IonToolbar, IonTitle, IonList, IonItem, IonLabel, AsyncPipe, NgFor],
+  templateUrl: './customers.page.html',
+  styleUrls: ['./customers.page.scss'],
+})
+export class CustomersPage {
+  private readonly fixtures = provideFixtures();
+  readonly customers$ = this.fixtures.customers$;
+}

--- a/frazer-ui/src/app/data/fixtures.ts
+++ b/frazer-ui/src/app/data/fixtures.ts
@@ -1,10 +1,12 @@
 import { inject } from '@angular/core';
 import { of } from 'rxjs';
 import {
+  CustomerSummary,
   InsuranceProvider,
   InventoryReportRow,
   JobStatus,
   PaymentDashboardItem,
+  Prospect,
   SaleSummary,
   TitlesPendingReportRow,
   VehicleSummary,
@@ -44,6 +46,57 @@ export const mockSales: SaleSummary[] = [
     createdOn: new Date().toISOString(),
   },
 ];
+
+export const mockCustomers: CustomerSummary[] = [
+  {
+    id: 'customer-1',
+    firstName: 'Jamie',
+    lastName: 'Wheeler',
+    email: 'jamie.wheeler@example.com',
+    phone: '555-0100',
+  },
+  {
+    id: 'customer-2',
+    firstName: 'Morgan',
+    lastName: 'Hughes',
+    email: 'morgan.hughes@example.com',
+    phone: '555-0200',
+  },
+];
+
+export const mockProspects: Prospect[] = mockVehicles.length
+  ? [
+      {
+        id: 'prospect-1',
+        name: 'Alex Johnson',
+        email: 'alex.johnson@example.com',
+        phone: '555-0400',
+        vehicles: [mockVehicles[0]].map((vehicle) => ({
+          id: vehicle.id,
+          stockNumber: vehicle.stockNumber,
+          year: vehicle.year,
+          make: vehicle.make,
+          model: vehicle.model,
+        })),
+      },
+      {
+        id: 'prospect-2',
+        name: 'Riley Chen',
+        email: 'riley.chen@example.com',
+        phone: '555-0500',
+        vehicles:
+          mockVehicles.length > 1
+            ? [mockVehicles[1]].map((vehicle) => ({
+                id: vehicle.id,
+                stockNumber: vehicle.stockNumber,
+                year: vehicle.year,
+                make: vehicle.make,
+                model: vehicle.model,
+              }))
+            : [],
+      },
+    ]
+  : [];
 
 export const mockPayments: PaymentDashboardItem[] = [
   {
@@ -109,5 +162,7 @@ export function provideFixtures(api = inject(ApiClientService)) {
     providers$: of(mockProviders),
     inventoryReport$: of(mockInventoryReport),
     titlesReport$: of(mockTitlesReport),
+    customers$: of(mockCustomers),
+    prospects$: of(mockProspects),
   };
 }

--- a/frazer-ui/src/app/prospects/prospects.page.html
+++ b/frazer-ui/src/app/prospects/prospects.page.html
@@ -1,0 +1,87 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Prospects</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-list>
+    <ion-item *ngFor="let prospect of prospects$ | async">
+      <ion-label>
+        <h2>{{ prospect.name }}</h2>
+        <p>{{ prospect.email }}</p>
+        <p>{{ prospect.phone }}</p>
+        <div class="vehicle-tags" *ngIf="prospect.vehicles.length">
+          <ion-chip *ngFor="let vehicle of prospect.vehicles">
+            <ion-label>{{ vehicle.stockNumber }} • {{ vehicle.year }} {{ vehicle.make }} {{ vehicle.model }}</ion-label>
+          </ion-chip>
+        </div>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+
+  <ion-fab slot="fixed" horizontal="end" vertical="bottom">
+    <ion-fab-button color="primary" (click)="openModal()">
+      <ion-icon name="add"></ion-icon>
+    </ion-fab-button>
+  </ion-fab>
+
+  <ion-modal [isOpen]="isModalOpen" (didDismiss)="handleModalDismiss()">
+    <ng-template>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Add Prospect</ion-title>
+          <ion-buttons slot="end">
+            <ion-button fill="clear" (click)="closeModal()">
+              <ion-icon name="close"></ion-icon>
+            </ion-button>
+          </ion-buttons>
+        </ion-toolbar>
+      </ion-header>
+
+      <ion-content class="ion-padding">
+        <form class="prospect-form" [formGroup]="form" (ngSubmit)="saveProspect()">
+          <ion-list>
+            <ion-item>
+              <ion-label position="stacked">Name</ion-label>
+              <ion-input formControlName="name" type="text"></ion-input>
+            </ion-item>
+            <ion-text color="danger" *ngIf="form.controls.name.touched && form.controls.name.invalid">
+              Name is required.
+            </ion-text>
+
+            <ion-item>
+              <ion-label position="stacked">Email</ion-label>
+              <ion-input formControlName="email" type="email"></ion-input>
+            </ion-item>
+            <ion-text color="danger" *ngIf="form.controls.email.touched && form.controls.email.invalid">
+              Enter a valid email.
+            </ion-text>
+
+            <ion-item>
+              <ion-label position="stacked">Phone</ion-label>
+              <ion-input formControlName="phone" type="tel"></ion-input>
+            </ion-item>
+            <ion-text color="danger" *ngIf="form.controls.phone.touched && form.controls.phone.invalid">
+              Phone is required.
+            </ion-text>
+
+            <ion-item>
+              <ion-label position="stacked">Interested Vehicles</ion-label>
+              <ion-select formControlName="vehicleIds" multiple="true" interface="popover" placeholder="Select vehicles">
+                <ion-select-option *ngFor="let vehicle of vehicles$ | async" [value]="vehicle.id">
+                  {{ vehicle.stockNumber }} — {{ vehicle.year }} {{ vehicle.make }} {{ vehicle.model }}
+                </ion-select-option>
+              </ion-select>
+            </ion-item>
+          </ion-list>
+
+          <div class="form-actions">
+            <ion-button type="button" fill="clear" (click)="closeModal()">Cancel</ion-button>
+            <ion-button type="submit" [disabled]="form.invalid">Add Prospect</ion-button>
+          </div>
+        </form>
+      </ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>

--- a/frazer-ui/src/app/prospects/prospects.page.scss
+++ b/frazer-ui/src/app/prospects/prospects.page.scss
@@ -1,0 +1,24 @@
+.vehicle-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.prospect-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+ion-text[color='danger'] {
+  margin-left: 1rem;
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0 0.5rem;
+}

--- a/frazer-ui/src/app/prospects/prospects.page.ts
+++ b/frazer-ui/src/app/prospects/prospects.page.ts
@@ -1,0 +1,132 @@
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  IonButton,
+  IonButtons,
+  IonChip,
+  IonContent,
+  IonFab,
+  IonFabButton,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonModal,
+  IonSelect,
+  IonSelectOption,
+  IonText,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
+import { BehaviorSubject, combineLatest, firstValueFrom, map } from 'rxjs';
+import { provideFixtures } from '../data/fixtures';
+import { Prospect, ProspectVehicleSummary, VehicleSummary } from '../shared/models';
+
+@Component({
+  selector: 'app-prospects',
+  standalone: true,
+  imports: [
+    IonContent,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonChip,
+    IonFab,
+    IonFabButton,
+    IonIcon,
+    IonModal,
+    IonButtons,
+    IonButton,
+    IonInput,
+    IonSelect,
+    IonSelectOption,
+    IonText,
+    ReactiveFormsModule,
+    AsyncPipe,
+    NgFor,
+    NgIf,
+  ],
+  templateUrl: './prospects.page.html',
+  styleUrls: ['./prospects.page.scss'],
+})
+export class ProspectsPage {
+  private readonly fixtures = provideFixtures();
+  private readonly fb = new FormBuilder();
+  private readonly addedProspects$ = new BehaviorSubject<Prospect[]>([]);
+
+  readonly vehicles$ = this.fixtures.vehicles$;
+  readonly baseProspects$ = this.fixtures.prospects$;
+  readonly prospects$ = combineLatest([this.baseProspects$, this.addedProspects$]).pipe(
+    map(([existing, added]) => [...existing, ...added])
+  );
+
+  readonly form = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    phone: ['', Validators.required],
+    vehicleIds: this.fb.nonNullable.control<string[]>([]),
+  });
+
+  isModalOpen = false;
+
+  openModal(): void {
+    this.isModalOpen = true;
+  }
+
+  closeModal(): void {
+    this.isModalOpen = false;
+  }
+
+  handleModalDismiss(): void {
+    this.form.reset({ name: '', email: '', phone: '', vehicleIds: [] });
+  }
+
+  async saveProspect(): Promise<void> {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const vehicles = await firstValueFrom(this.vehicles$);
+    const selectedVehicleIds = this.form.controls.vehicleIds.value;
+    const selectedVehicles: ProspectVehicleSummary[] = vehicles
+      .filter((vehicle) => selectedVehicleIds.includes(vehicle.id))
+      .map((vehicle) => this.toProspectVehicle(vehicle));
+
+    const prospect: Prospect = {
+      id: this.generateId(),
+      name: this.form.controls.name.value,
+      email: this.form.controls.email.value,
+      phone: this.form.controls.phone.value,
+      vehicles: selectedVehicles,
+    };
+
+    const current = this.addedProspects$.value;
+    this.addedProspects$.next([...current, prospect]);
+
+    this.closeModal();
+    this.handleModalDismiss();
+  }
+
+  private toProspectVehicle(vehicle: VehicleSummary): ProspectVehicleSummary {
+    return {
+      id: vehicle.id,
+      stockNumber: vehicle.stockNumber,
+      year: vehicle.year,
+      make: vehicle.make,
+      model: vehicle.model,
+    };
+  }
+
+  private generateId(): string {
+    return typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2);
+  }
+}

--- a/frazer-ui/src/app/shared/models.ts
+++ b/frazer-ui/src/app/shared/models.ts
@@ -26,6 +26,22 @@ export interface VehicleDetail extends VehicleSummary {
   currentSaleId?: string;
 }
 
+export interface ProspectVehicleSummary {
+  id: string;
+  stockNumber: string;
+  year: string;
+  make: string;
+  model: string;
+}
+
+export interface Prospect {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  vehicles: ProspectVehicleSummary[];
+}
+
 export interface CustomerSummary {
   id: string;
   firstName: string;

--- a/frazer-ui/src/app/shell/main-layout.component.ts
+++ b/frazer-ui/src/app/shell/main-layout.component.ts
@@ -19,7 +19,19 @@ import {
 } from '@ionic/angular/standalone';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { addIcons } from 'ionicons';
-import { documentTextOutline, keyOutline, peopleOutline, receiptOutline, speedometerOutline, swapHorizontalOutline, walletOutline, warningOutline, cloudUploadOutline, constructOutline } from 'ionicons/icons';
+import {
+  documentTextOutline,
+  keyOutline,
+  peopleOutline,
+  personAddOutline,
+  receiptOutline,
+  speedometerOutline,
+  swapHorizontalOutline,
+  walletOutline,
+  warningOutline,
+  cloudUploadOutline,
+  constructOutline,
+} from 'ionicons/icons';
 import { AuthService } from '../auth/auth.service';
 import { Role } from '../shared/models';
 
@@ -68,6 +80,7 @@ export class MainLayoutComponent {
       documentTextOutline,
       peopleOutline,
       swapHorizontalOutline,
+      personAddOutline,
       receiptOutline,
       warningOutline,
       keyOutline,
@@ -80,6 +93,8 @@ export class MainLayoutComponent {
   readonly items: NavItem[] = [
     { label: 'Dashboard', icon: 'speedometer-outline', path: '/dashboard' },
     { label: 'Inventory', icon: 'document-text-outline', path: '/inventory' },
+    { label: 'Customers', icon: 'people-outline', path: '/customers' },
+    { label: 'Prospects', icon: 'person-add-outline', path: '/prospects' },
     { label: 'Sales', icon: 'swap-horizontal-outline', path: '/sales' },
     { label: 'Titles', icon: 'warning-outline', path: '/titles' },
     { label: 'Insurance', icon: 'key-outline', path: '/insurance' },

--- a/frazer-ui/src/app/shell/shell.routes.ts
+++ b/frazer-ui/src/app/shell/shell.routes.ts
@@ -16,6 +16,14 @@ export const SHELL_ROUTES: Routes = [
         loadComponent: () => import('../inventory/inventory.page').then((m) => m.InventoryPage),
       },
       {
+        path: 'customers',
+        loadComponent: () => import('../customers/customers.page').then((m) => m.CustomersPage),
+      },
+      {
+        path: 'prospects',
+        loadComponent: () => import('../prospects/prospects.page').then((m) => m.ProspectsPage),
+      },
+      {
         path: 'sales',
         loadChildren: () => import('../sales/sales.routes').then((m) => m.SALES_ROUTES),
       },


### PR DESCRIPTION
## Summary
- add a Prospect domain model, API contracts, controller, and EF migration to persist prospect to vehicle relationships
- register a prospect service with seed data so initial environments expose prospect information
- extend the Ionic UI with customers and prospects sections, including a modal form and FAB to capture new prospects linked to vehicles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68eae9d7ae308331b9e22ebd0596d5ff