### PR TITLE
Fix EF Core prospect navigation configuration

### DIFF
--- a/frazer-api/src/Domain/Entities/Prospect.cs
+++ b/frazer-api/src/Domain/Entities/Prospect.cs
@@ -7,5 +7,5 @@ public class Prospect
     public string Email { get; set; } = string.Empty;
     public string Phone { get; set; } = string.Empty;
 
-    public List<Vehicle> Vehicles { get; set; } = new();
+    public ICollection<Vehicle> Vehicles { get; set; } = new List<Vehicle>();
 }

--- a/frazer-api/src/Domain/Entities/Vehicle.cs
+++ b/frazer-api/src/Domain/Entities/Vehicle.cs
@@ -17,5 +17,5 @@ public class Vehicle
     public Guid? CurrentSaleId { get; set; }
     public Sale? CurrentSale { get; set; }
     public List<Sale> SalesHistory { get; set; } = new();
-    public List<Prospect> Prospects { get; set; } = new();
+    public ICollection<Prospect> Prospects { get; set; } = new List<Prospect>();
 }

--- a/frazer-api/src/Infrastructure/Persistence/AppDbContext.cs
+++ b/frazer-api/src/Infrastructure/Persistence/AppDbContext.cs
@@ -41,10 +41,6 @@ public class AppDbContext : DbContext
         modelBuilder.Entity<Prospect>(entity =>
         {
             entity.HasKey(e => e.Id);
-
-            entity.HasMany(e => e.Vehicles)
-                .WithMany(e => e.Prospects)
-                .UsingEntity(j => j.ToTable("ProspectVehicle"));
         });
 
         modelBuilder.Entity<Sale>(entity =>

--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -21,5 +21,9 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
         builder.HasMany(v => v.SalesHistory)
             .WithOne(s => s.Vehicle)
             .HasForeignKey(s => s.VehicleId);
+
+        builder.HasMany(v => v.Prospects)
+            .WithMany(p => p.Vehicles)
+            .UsingEntity(j => j.ToTable("ProspectVehicle"));
     }
 }


### PR DESCRIPTION
## Summary
- expose vehicle-to-prospect relationship using ICollection navigation properties
- configure the vehicle/prospect many-to-many join through the vehicle entity configuration to keep the model snapshot consistent

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68eaf16c512c833196e454b8561bfe8c