### PR TITLE
Fix AppDbContext snapshot prospect navigation configuration

### DIFF
--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FrazerDealer.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -205,6 +206,8 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.HasKey("Id");
 
             b.ToTable("Prospects");
+
+            b.Navigation("Vehicles");
         });
 
         modelBuilder.Entity("FrazerDealer.Domain.Entities.RecurringJob", b =>
@@ -408,6 +411,20 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
                 .WithMany()
                 .HasForeignKey("CurrentSaleId")
                 .OnDelete(DeleteBehavior.SetNull);
+
+            b.HasMany("FrazerDealer.Domain.Entities.Prospect", "Prospects")
+                .WithMany("Vehicles")
+                .UsingEntity<Dictionary<string, object>>("ProspectVehicle",
+                    r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", null)
+                        .WithMany()
+                        .HasForeignKey("ProspectsId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired(),
+                    l => l.HasOne("FrazerDealer.Domain.Entities.Vehicle", null)
+                        .WithMany()
+                        .HasForeignKey("VehiclesId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired());
 
             b.Navigation("CurrentSale");
         });


### PR DESCRIPTION
## Summary
- add missing System.Collections.Generic import to the AppDbContext model snapshot
- configure the Vehicle->Prospect relationship in the snapshot so the Prospects navigation is defined
- register the Prospect navigation for Vehicles within the snapshot to align with the entity model

## Testing
- `DOTNET_CLI_UI_LANGUAGE=en dotnet ef migrations list --project src/Infrastructure --startup-project src/Api` *(fails: dotnet command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68eaf6702c1483318fc529422e5273d5