### PR TITLE
Fix prospect-vehicle join entity configuration

### DIFF
--- a/frazer-api/src/Domain/Entities/Prospect.cs
+++ b/frazer-api/src/Domain/Entities/Prospect.cs
@@ -8,4 +8,5 @@ public class Prospect
     public string Phone { get; set; } = string.Empty;
 
     public ICollection<Vehicle> Vehicles { get; set; } = new List<Vehicle>();
+    public ICollection<ProspectVehicle> ProspectVehicles { get; set; } = new List<ProspectVehicle>();
 }

--- a/frazer-api/src/Domain/Entities/ProspectVehicle.cs
+++ b/frazer-api/src/Domain/Entities/ProspectVehicle.cs
@@ -1,0 +1,10 @@
+namespace FrazerDealer.Domain.Entities;
+
+public class ProspectVehicle
+{
+    public Guid ProspectId { get; set; }
+    public Prospect Prospect { get; set; } = null!;
+
+    public Guid VehicleId { get; set; }
+    public Vehicle Vehicle { get; set; } = null!;
+}

--- a/frazer-api/src/Domain/Entities/Vehicle.cs
+++ b/frazer-api/src/Domain/Entities/Vehicle.cs
@@ -18,4 +18,5 @@ public class Vehicle
     public Sale? CurrentSale { get; set; }
     public List<Sale> SalesHistory { get; set; } = new();
     public ICollection<Prospect> Prospects { get; set; } = new List<Prospect>();
+    public ICollection<ProspectVehicle> ProspectVehicles { get; set; } = new List<ProspectVehicle>();
 }

--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -24,6 +24,17 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
 
         builder.HasMany(v => v.Prospects)
             .WithMany(p => p.Vehicles)
-            .UsingEntity(j => j.ToTable("ProspectVehicle"));
+            .UsingEntity<ProspectVehicle>(
+                j => j.HasOne(pv => pv.Prospect)
+                    .WithMany(p => p.ProspectVehicles)
+                    .HasForeignKey(pv => pv.ProspectId),
+                j => j.HasOne(pv => pv.Vehicle)
+                    .WithMany(v => v.ProspectVehicles)
+                    .HasForeignKey(pv => pv.VehicleId),
+                j =>
+                {
+                    j.HasKey(t => new { t.ProspectId, t.VehicleId });
+                    j.ToTable("ProspectVehicle");
+                });
     }
 }

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/20240501000000_AddProspects.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/20240501000000_AddProspects.cs
@@ -27,30 +27,30 @@ public partial class AddProspects : Migration
             name: "ProspectVehicle",
             columns: table => new
             {
-                ProspectsId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                VehiclesId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                ProspectId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                VehicleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
             },
             constraints: table =>
             {
-                table.PrimaryKey("PK_ProspectVehicle", x => new { x.ProspectsId, x.VehiclesId });
+                table.PrimaryKey("PK_ProspectVehicle", x => new { x.ProspectId, x.VehicleId });
                 table.ForeignKey(
-                    name: "FK_ProspectVehicle_Prospects_ProspectsId",
-                    column: x => x.ProspectsId,
+                    name: "FK_ProspectVehicle_Prospects_ProspectId",
+                    column: x => x.ProspectId,
                     principalTable: "Prospects",
                     principalColumn: "Id",
                     onDelete: ReferentialAction.Cascade);
                 table.ForeignKey(
-                    name: "FK_ProspectVehicle_Vehicles_VehiclesId",
-                    column: x => x.VehiclesId,
+                    name: "FK_ProspectVehicle_Vehicles_VehicleId",
+                    column: x => x.VehicleId,
                     principalTable: "Vehicles",
                     principalColumn: "Id",
                     onDelete: ReferentialAction.Cascade);
             });
 
         migrationBuilder.CreateIndex(
-            name: "IX_ProspectVehicle_VehiclesId",
+            name: "IX_ProspectVehicle_VehicleId",
             table: "ProspectVehicle",
-            column: "VehiclesId");
+            column: "VehicleId");
     }
 
     protected override void Down(MigrationBuilder migrationBuilder)

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -207,6 +207,8 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
             b.ToTable("Prospects");
 
+            b.Navigation("ProspectVehicles");
+
             b.Navigation("Vehicles");
         });
 
@@ -338,17 +340,17 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.ToTable("Vehicles");
         });
 
-        modelBuilder.Entity("ProspectVehicle", b =>
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.ProspectVehicle", b =>
         {
-            b.Property<Guid>("ProspectsId")
+            b.Property<Guid>("ProspectId")
                 .HasColumnType("uniqueidentifier");
 
-            b.Property<Guid>("VehiclesId")
+            b.Property<Guid>("VehicleId")
                 .HasColumnType("uniqueidentifier");
 
-            b.HasKey("ProspectsId", "VehiclesId");
+            b.HasKey("ProspectId", "VehicleId");
 
-            b.HasIndex("VehiclesId");
+            b.HasIndex("VehicleId");
 
             b.ToTable("ProspectVehicle", (string)null);
         });
@@ -414,34 +416,44 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
             b.HasMany("FrazerDealer.Domain.Entities.Prospect", "Prospects")
                 .WithMany("Vehicles")
-                .UsingEntity<Dictionary<string, object>>("ProspectVehicle",
-                    r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", null)
-                        .WithMany()
-                        .HasForeignKey("ProspectsId")
+                .UsingEntity<FrazerDealer.Domain.Entities.ProspectVehicle>(
+                    "ProspectVehicle",
+                    r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
+                        .WithMany("ProspectVehicles")
+                        .HasForeignKey("ProspectId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired(),
-                    l => l.HasOne("FrazerDealer.Domain.Entities.Vehicle", null)
-                        .WithMany()
-                        .HasForeignKey("VehiclesId")
+                    l => l.HasOne("FrazerDealer.Domain.Entities.Vehicle", "Vehicle")
+                        .WithMany("ProspectVehicles")
+                        .HasForeignKey("VehicleId")
                         .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired());
+                        .IsRequired(),
+                    j =>
+                    {
+                        j.HasKey("ProspectId", "VehicleId");
+                        j.ToTable("ProspectVehicle");
+                    });
 
             b.Navigation("CurrentSale");
         });
 
-        modelBuilder.Entity("ProspectVehicle", b =>
+        modelBuilder.Entity("FrazerDealer.Domain.Entities.ProspectVehicle", b =>
         {
-            b.HasOne("FrazerDealer.Domain.Entities.Prospect", null)
-                .WithMany()
-                .HasForeignKey("ProspectsId")
+            b.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
+                .WithMany("ProspectVehicles")
+                .HasForeignKey("ProspectId")
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
 
-            b.HasOne("FrazerDealer.Domain.Entities.Vehicle", null)
-                .WithMany()
-                .HasForeignKey("VehiclesId")
+            b.HasOne("FrazerDealer.Domain.Entities.Vehicle", "Vehicle")
+                .WithMany("ProspectVehicles")
+                .HasForeignKey("VehicleId")
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
+
+            b.Navigation("Prospect");
+
+            b.Navigation("Vehicle");
         });
 
         modelBuilder.Entity("FrazerDealer.Domain.Entities.Customer", b =>
@@ -458,6 +470,8 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
         modelBuilder.Entity("FrazerDealer.Domain.Entities.Vehicle", b =>
         {
+            b.Navigation("ProspectVehicles");
+
             b.Navigation("Prospects");
 
             b.Navigation("SalesHistory");


### PR DESCRIPTION
## Summary
- add an explicit ProspectVehicle join entity and navigation properties for prospects and vehicles
- reconfigure the Vehicle entity to use the typed join entity and align migrations/model snapshot naming

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68eaf8241ae483318a461d5eb62c6712