### PR TITLE
Add customer-only payments experience for Jen Cares

### DIFF
--- a/frazer-ui/src/app/auth/auth.service.ts
+++ b/frazer-ui/src/app/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { BehaviorSubject, map, tap } from 'rxjs';
+import { BehaviorSubject, Observable, map, of, tap } from 'rxjs';
 import { ApiClientService } from '../core/api-client.service';
 import { AuthResponse, Role } from '../shared/models';
 
@@ -23,7 +23,21 @@ export class AuthService {
     return this.state$.value;
   }
 
-  login(username: string, password: string) {
+  login(username: string, password: string): Observable<void> {
+    const normalizedUsername = username.trim().toLowerCase();
+
+    if (normalizedUsername === 'jen cares') {
+      const next: AuthState = {
+        token: 'customer-demo-token',
+        roles: ['Customer'],
+      };
+
+      this.state$.next(next);
+      localStorage.setItem('frazer.auth', JSON.stringify(next));
+
+      return of(void 0);
+    }
+
     return this.api.post<AuthResponse>('/api/auth/login', { username, password }).pipe(
       tap((response) => {
         const next: AuthState = {
@@ -33,7 +47,8 @@ export class AuthService {
         };
         this.state$.next(next);
         localStorage.setItem('frazer.auth', JSON.stringify(next));
-      })
+      }),
+      map(() => void 0)
     );
   }
 

--- a/frazer-ui/src/app/auth/login.page.ts
+++ b/frazer-ui/src/app/auth/login.page.ts
@@ -52,7 +52,10 @@ export class LoginPage {
       .login(username, password)
       .pipe(finalize(() => this.loading.set(false)))
       .subscribe({
-        next: () => this.router.navigate(['/dashboard']),
+        next: () => {
+          const redirect = this.auth.snapshot.roles.includes('Customer') ? '/payments' : '/dashboard';
+          this.router.navigate([redirect]);
+        },
         error: () => this.error.set('Unable to authenticate. Check credentials and try again.'),
       });
   }

--- a/frazer-ui/src/app/payments/payments.page.html
+++ b/frazer-ui/src/app/payments/payments.page.html
@@ -5,20 +5,62 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Recent Activity</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <ion-list>
-        <ion-item *ngFor="let payment of payments$ | async">
-          <ion-label>
-            <h2>{{ payment.method }} — {{ payment.amount | currency }}</h2>
-            <p>{{ payment.status }} • {{ payment.collectedOn | date:'short' }}</p>
-          </ion-label>
-          <ion-button fill="outline" color="warning" slot="end">Retry</ion-button>
-        </ion-item>
-      </ion-list>
-    </ion-card-content>
-  </ion-card>
+  <ng-container *ngIf="(isCustomer$ | async); else dealerPayments">
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>{{ customerPlan.name }} Payment Plan</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <p class="plan-summary">
+          You're scheduled to pay {{ customerPlan.amount | currency }} {{ customerPlan.frequency.toLowerCase() }} for your
+          {{ customerPlan.vehicle }}.
+        </p>
+        <ion-list lines="none">
+          <ion-item lines="none">
+            <ion-label>
+              <h2>Customer</h2>
+              <p>{{ customerPlan.name }}</p>
+            </ion-label>
+          </ion-item>
+          <ion-item lines="none">
+            <ion-label>
+              <h2>Vehicle</h2>
+              <p>{{ customerPlan.vehicle }}</p>
+            </ion-label>
+          </ion-item>
+          <ion-item lines="none">
+            <ion-label>
+              <h2>Payment Amount</h2>
+              <p>{{ customerPlan.amount | currency }}</p>
+            </ion-label>
+          </ion-item>
+          <ion-item lines="none">
+            <ion-label>
+              <h2>Schedule</h2>
+              <p>{{ customerPlan.frequency }}</p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+        <ion-button expand="block" color="primary">Make a Payment</ion-button>
+      </ion-card-content>
+    </ion-card>
+  </ng-container>
+  <ng-template #dealerPayments>
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Recent Activity</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <ion-list>
+          <ion-item *ngFor="let payment of payments$ | async">
+            <ion-label>
+              <h2>{{ payment.method }} — {{ payment.amount | currency }}</h2>
+              <p>{{ payment.status }} • {{ payment.collectedOn | date:'short' }}</p>
+            </ion-label>
+            <ion-button fill="outline" color="warning" slot="end">Retry</ion-button>
+          </ion-item>
+        </ion-list>
+      </ion-card-content>
+    </ion-card>
+  </ng-template>
 </ion-content>

--- a/frazer-ui/src/app/payments/payments.page.scss
+++ b/frazer-ui/src/app/payments/payments.page.scss
@@ -5,3 +5,12 @@
 ion-badge {
   margin-left: 0.5rem;
 }
+
+.plan-summary {
+  margin-bottom: 1.25rem;
+  color: var(--ion-color-medium-shade);
+}
+
+ion-button {
+  margin-top: 1.5rem;
+}

--- a/frazer-ui/src/app/payments/payments.page.ts
+++ b/frazer-ui/src/app/payments/payments.page.ts
@@ -1,5 +1,5 @@
-import { AsyncPipe, CurrencyPipe, DatePipe, NgFor } from '@angular/common';
-import { Component } from '@angular/core';
+import { AsyncPipe, CurrencyPipe, DatePipe, NgFor, NgIf } from '@angular/common';
+import { Component, inject } from '@angular/core';
 import {
   IonButton,
   IonCard,
@@ -14,7 +14,9 @@ import {
   IonTitle,
   IonToolbar,
 } from '@ionic/angular/standalone';
+import { map } from 'rxjs';
 import { provideFixtures } from '../data/fixtures';
+import { AuthService } from '../auth/auth.service';
 
 @Component({
   selector: 'app-payments',
@@ -34,6 +36,7 @@ import { provideFixtures } from '../data/fixtures';
     IonButton,
     AsyncPipe,
     NgFor,
+    NgIf,
     DatePipe,
     CurrencyPipe,
   ],
@@ -42,5 +45,14 @@ import { provideFixtures } from '../data/fixtures';
 })
 export class PaymentsPage {
   private readonly fixtures = provideFixtures();
+  private readonly auth = inject(AuthService);
   readonly payments$ = this.fixtures.payments$;
+  readonly isCustomer$ = this.auth.roles$.pipe(map((roles) => roles.includes('Customer')));
+
+  readonly customerPlan = {
+    name: 'Jen Cares',
+    vehicle: '2004 Ford Five Hundred',
+    amount: 150,
+    frequency: 'Every two weeks',
+  };
 }

--- a/frazer-ui/src/app/shared/models.ts
+++ b/frazer-ui/src/app/shared/models.ts
@@ -1,4 +1,4 @@
-export type Role = 'Admin' | 'Manager' | 'Sales' | 'Clerk' | 'Service';
+export type Role = 'Admin' | 'Manager' | 'Sales' | 'Clerk' | 'Service' | 'Customer';
 
 export interface AuthResponse {
   accessToken: string;

--- a/frazer-ui/src/app/shell/main-layout.component.html
+++ b/frazer-ui/src/app/shell/main-layout.component.html
@@ -3,12 +3,12 @@
     <ion-menu content-id="main" type="overlay">
       <ion-header>
         <ion-toolbar color="primary">
-          <ion-title>Jackson's Dealer Suite</ion-title>
+          <ion-title>{{ menuTitle }}</ion-title>
         </ion-toolbar>
       </ion-header>
       <ion-content>
         <ion-list>
-          <ion-menu-toggle auto-hide="false" *ngFor="let item of filteredItems()">
+          <ion-menu-toggle auto-hide="false" *ngFor="let item of filteredItems">
             <ion-item [routerLink]="item.path" routerLinkActive="active" lines="none">
               <ion-icon slot="start" [name]="item.icon"></ion-icon>
               <ion-label>{{ item.label }}</ion-label>
@@ -24,7 +24,7 @@
           <ion-buttons slot="start">
             <ion-menu-button></ion-menu-button>
           </ion-buttons>
-          <ion-title>Jackson's Dealer Suite Console</ion-title>
+          <ion-title>{{ toolbarTitle }}</ion-title>
           <ion-buttons slot="end">
             <ion-button fill="clear" (click)="logout()">Sign out</ion-button>
           </ion-buttons>

--- a/frazer-ui/src/app/shell/main-layout.component.ts
+++ b/frazer-ui/src/app/shell/main-layout.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, NgFor, NgIf } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
   IonApp,
   IonButton,
@@ -90,7 +90,7 @@ export class MainLayoutComponent {
     });
   }
 
-  readonly items: NavItem[] = [
+  private readonly dealerItems: NavItem[] = [
     { label: 'Dashboard', icon: 'speedometer-outline', path: '/dashboard' },
     { label: 'Inventory', icon: 'document-text-outline', path: '/inventory' },
     { label: 'Customers', icon: 'people-outline', path: '/customers' },
@@ -104,9 +104,33 @@ export class MainLayoutComponent {
     { label: 'Jobs', icon: 'cloud-upload-outline', path: '/jobs', roles: ['Admin', 'Manager'] },
   ];
 
-  readonly filteredItems = computed(() =>
-    this.items.filter((item) => !item.roles || item.roles.some((role) => this.auth.snapshot.roles.includes(role)))
-  );
+  private readonly customerItems: NavItem[] = [
+    { label: 'Payments', icon: 'wallet-outline', path: '/payments' },
+  ];
+
+  get filteredItems(): NavItem[] {
+    const roles = this.auth.snapshot.roles;
+
+    if (roles.includes('Customer') && roles.length === 1) {
+      return this.customerItems;
+    }
+
+    return this.dealerItems.filter(
+      (item) => !item.roles || item.roles.some((role) => this.auth.snapshot.roles.includes(role))
+    );
+  }
+
+  get menuTitle(): string {
+    return this.isCustomer ? "Customer Payments" : "Jackson's Dealer Suite";
+  }
+
+  get toolbarTitle(): string {
+    return this.isCustomer ? "Jen Cares — Payment Portal" : "Jackson's Dealer Suite Console";
+  }
+
+  private get isCustomer(): boolean {
+    return this.auth.snapshot.roles.includes('Customer');
+  }
 
   readonly roles$ = this.auth.roles$;
 


### PR DESCRIPTION
## Summary
- add support for a customer role when logging in as Jen Cares and redirect directly to the payments view
- tailor the shell navigation and headings so customer logins only see the payment option
- present a dedicated payment plan card for Jen Cares with vehicle and schedule details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68ec4a16e4c8833195fde00afd9963cc