### PR TITLE
Fix join entity mapping without generic UsingEntity overload

### DIFF
--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -24,16 +24,19 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
 
         builder.HasMany(v => v.Prospects)
             .WithMany(p => p.Vehicles)
-            .UsingEntity<ProspectVehicle>(
-                j => j.HasOne(pv => pv.Prospect)
-                    .WithMany(p => p.ProspectVehicles)
-                    .HasForeignKey(pv => pv.ProspectId),
-                j => j.HasOne(pv => pv.Vehicle)
-                    .WithMany(v => v.ProspectVehicles)
-                    .HasForeignKey(pv => pv.VehicleId),
+            .UsingEntity(
+                typeof(ProspectVehicle),
+                j => j.HasOne(typeof(Prospect))
+                    .WithMany(nameof(Prospect.ProspectVehicles))
+                    .HasForeignKey(nameof(ProspectVehicle.ProspectId))
+                    .OnDelete(DeleteBehavior.Cascade),
+                j => j.HasOne(typeof(Vehicle))
+                    .WithMany(nameof(Vehicle.ProspectVehicles))
+                    .HasForeignKey(nameof(ProspectVehicle.VehicleId))
+                    .OnDelete(DeleteBehavior.Cascade),
                 j =>
                 {
-                    j.HasKey(t => new { t.ProspectId, t.VehicleId });
+                    j.HasKey(nameof(ProspectVehicle.ProspectId), nameof(ProspectVehicle.VehicleId));
                     j.ToTable("ProspectVehicle");
                 });
     }

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -416,8 +416,8 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
             b.HasMany("FrazerDealer.Domain.Entities.Prospect", "Prospects")
                 .WithMany("Vehicles")
-                .UsingEntity<FrazerDealer.Domain.Entities.ProspectVehicle>(
-                    "ProspectVehicle",
+                .UsingEntity(
+                    typeof(FrazerDealer.Domain.Entities.ProspectVehicle),
                     r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
                         .WithMany("ProspectVehicles")
                         .HasForeignKey("ProspectId")


### PR DESCRIPTION
## Summary
- update the vehicle configuration to use the non-generic UsingEntity overload so the join entity mapping compiles without errors
- align the model snapshot with the updated configuration

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68eda3d8786883319861b63006a9ee8e