### PR TITLE
Add launch settings for API development

### DIFF
--- a/frazer-api/src/Api/Properties/launchSettings.json
+++ b/frazer-api/src/Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a launchSettings.json file for the API project
- configure the default profile to run with the Development environment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68eda7e1e3648331a96019cd32c73f3a