### PR TITLE
Fix many-to-many configuration without generic UsingEntity

### DIFF
--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -24,16 +24,17 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
 
         builder.HasMany(v => v.Prospects)
             .WithMany(p => p.Vehicles)
-            .UsingEntity<ProspectVehicle>(
-                j => j.HasOne(pv => pv.Prospect)
-                    .WithMany(p => p.ProspectVehicles)
-                    .HasForeignKey(pv => pv.ProspectId),
-                j => j.HasOne(pv => pv.Vehicle)
-                    .WithMany(v => v.ProspectVehicles)
-                    .HasForeignKey(pv => pv.VehicleId),
-                j =>
+            .UsingEntity(
+                joinEntityType: typeof(ProspectVehicle),
+                configureRight: j => j.HasOne(nameof(ProspectVehicle.Prospect))
+                    .WithMany(nameof(Prospect.ProspectVehicles))
+                    .HasForeignKey(nameof(ProspectVehicle.ProspectId)),
+                configureLeft: j => j.HasOne(nameof(ProspectVehicle.Vehicle))
+                    .WithMany(nameof(Vehicle.ProspectVehicles))
+                    .HasForeignKey(nameof(ProspectVehicle.VehicleId)),
+                configureJoinEntityType: j =>
                 {
-                    j.HasKey(t => new { t.ProspectId, t.VehicleId });
+                    j.HasKey(nameof(ProspectVehicle.ProspectId), nameof(ProspectVehicle.VehicleId));
                     j.ToTable("ProspectVehicle");
                 });
     }

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -416,8 +416,9 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
             b.HasMany("FrazerDealer.Domain.Entities.Prospect", "Prospects")
                 .WithMany("Vehicles")
-                .UsingEntity<FrazerDealer.Domain.Entities.ProspectVehicle>(
+                .UsingEntity(
                     "ProspectVehicle",
+                    typeof(FrazerDealer.Domain.Entities.ProspectVehicle),
                     r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
                         .WithMany("ProspectVehicles")
                         .HasForeignKey("ProspectId")


### PR DESCRIPTION
## Summary
- switch the Vehicle/Prospect many-to-many mapping to the non-generic `UsingEntity` overload to avoid the type argument error
- update the model snapshot to mirror the revised join entity configuration

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_b_68eb7c1a01e08331be4396d53838bc83