### PR TITLE
Fix EF Core join entity mapping for prospects and vehicles

### DIFF
--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -24,19 +24,18 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
 
         builder.HasMany(v => v.Prospects)
             .WithMany(p => p.Vehicles)
-            .UsingEntity(
-                typeof(ProspectVehicle),
-                j => j.HasOne(typeof(Prospect))
-                    .WithMany(nameof(Prospect.ProspectVehicles))
-                    .HasForeignKey(nameof(ProspectVehicle.ProspectId))
+            .UsingEntity<ProspectVehicle>(
+                j => j.HasOne(pv => pv.Prospect)
+                    .WithMany(p => p.ProspectVehicles)
+                    .HasForeignKey(pv => pv.ProspectId)
                     .OnDelete(DeleteBehavior.Cascade),
-                j => j.HasOne(typeof(Vehicle))
-                    .WithMany(nameof(Vehicle.ProspectVehicles))
-                    .HasForeignKey(nameof(ProspectVehicle.VehicleId))
+                j => j.HasOne(pv => pv.Vehicle)
+                    .WithMany(v => v.ProspectVehicles)
+                    .HasForeignKey(pv => pv.VehicleId)
                     .OnDelete(DeleteBehavior.Cascade),
                 j =>
                 {
-                    j.HasKey(nameof(ProspectVehicle.ProspectId), nameof(ProspectVehicle.VehicleId));
+                    j.HasKey(pv => new { pv.ProspectId, pv.VehicleId });
                     j.ToTable("ProspectVehicle");
                 });
     }


### PR DESCRIPTION
## Summary
- update the vehicle configuration to use a strongly typed join entity for the ProspectVehicle table
- ensure the ProspectVehicle foreign keys map directly to their navigation properties to avoid shadow properties

## Testing
- dotnet ef migrations list --project src/Infrastructure --startup-project src/Api *(fails: dotnet CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68f297029f1c8331a489bcbe84e3cd1b