### PR TITLE
Remove ProspectVehicles navigation to fix migrations

### DIFF
--- a/frazer-api/src/Domain/Entities/Prospect.cs
+++ b/frazer-api/src/Domain/Entities/Prospect.cs
@@ -8,5 +8,4 @@ public class Prospect
     public string Phone { get; set; } = string.Empty;
 
     public ICollection<Vehicle> Vehicles { get; set; } = new List<Vehicle>();
-    public ICollection<ProspectVehicle> ProspectVehicles { get; set; } = new List<ProspectVehicle>();
 }

--- a/frazer-api/src/Domain/Entities/Vehicle.cs
+++ b/frazer-api/src/Domain/Entities/Vehicle.cs
@@ -18,6 +18,5 @@ public class Vehicle
     public Sale? CurrentSale { get; set; }
     public List<Sale> SalesHistory { get; set; } = new();
     public ICollection<Prospect> Prospects { get; set; } = new List<Prospect>();
-    public ICollection<ProspectVehicle> ProspectVehicles { get; set; } = new List<ProspectVehicle>();
     public ICollection<Photo> Photos { get; set; } = new List<Photo>();
 }

--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -26,11 +26,11 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
             .WithMany(p => p.Vehicles)
             .UsingEntity<ProspectVehicle>(
                 j => j.HasOne(pv => pv.Prospect)
-                    .WithMany(p => p.ProspectVehicles)
+                    .WithMany()
                     .HasForeignKey(pv => pv.ProspectId)
                     .OnDelete(DeleteBehavior.Cascade),
                 j => j.HasOne(pv => pv.Vehicle)
-                    .WithMany(v => v.ProspectVehicles)
+                    .WithMany()
                     .HasForeignKey(pv => pv.VehicleId)
                     .OnDelete(DeleteBehavior.Cascade),
                 j =>

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -233,8 +233,6 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
             b.ToTable("Prospects");
 
-            b.Navigation("ProspectVehicles");
-
             b.Navigation("Vehicles");
         });
 
@@ -456,12 +454,12 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
                 .UsingEntity(
                     typeof(FrazerDealer.Domain.Entities.ProspectVehicle),
                     r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
-                        .WithMany("ProspectVehicles")
+                        .WithMany()
                         .HasForeignKey("ProspectId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired(),
                     l => l.HasOne("FrazerDealer.Domain.Entities.Vehicle", "Vehicle")
-                        .WithMany("ProspectVehicles")
+                        .WithMany()
                         .HasForeignKey("VehicleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired(),
@@ -477,13 +475,13 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
         modelBuilder.Entity("FrazerDealer.Domain.Entities.ProspectVehicle", b =>
         {
             b.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
-                .WithMany("ProspectVehicles")
+                .WithMany()
                 .HasForeignKey("ProspectId")
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
 
             b.HasOne("FrazerDealer.Domain.Entities.Vehicle", "Vehicle")
-                .WithMany("ProspectVehicles")
+                .WithMany()
                 .HasForeignKey("VehicleId")
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
@@ -508,8 +506,6 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
         modelBuilder.Entity("FrazerDealer.Domain.Entities.Vehicle", b =>
         {
             b.Navigation("Photos");
-
-            b.Navigation("ProspectVehicles");
 
             b.Navigation("Prospects");
 


### PR DESCRIPTION
## Summary
- remove the unused ProspectVehicles navigation collections from the domain models
- update the vehicle configuration to map the ProspectVehicle join entity without navigation collections
- align the model snapshot with the updated relationship configuration so migrations scaffold correctly

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68f29981b2708331b5b2ccec77fd5053