### PR TITLE
Fix prospect-vehicle mapping snapshot

### DIFF
--- a/frazer-api/src/Infrastructure/Persistence/Configurations/ProspectConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/ProspectConfiguration.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using FrazerDealer.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FrazerDealer.Infrastructure.Persistence.Configurations;
+
+public class ProspectConfiguration : IEntityTypeConfiguration<Prospect>
+{
+    public void Configure(EntityTypeBuilder<Prospect> builder)
+    {
+        builder.HasKey(p => p.Id);
+
+        builder.HasMany(p => p.Vehicles)
+            .WithMany(v => v.Prospects)
+            .UsingEntity<Dictionary<string, object>>(
+                "ProspectVehicle",
+                j => j.HasOne<Vehicle>()
+                    .WithMany()
+                    .HasForeignKey("VehicleId")
+                    .OnDelete(DeleteBehavior.Cascade),
+                j => j.HasOne<Prospect>()
+                    .WithMany()
+                    .HasForeignKey("ProspectId")
+                    .OnDelete(DeleteBehavior.Cascade),
+                j =>
+                {
+                    j.HasKey("ProspectId", "VehicleId");
+                    j.ToTable("ProspectVehicle");
+                });
+    }
+}

--- a/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -22,21 +22,5 @@ public class VehicleConfiguration : IEntityTypeConfiguration<Vehicle>
             .WithOne(s => s.Vehicle)
             .HasForeignKey(s => s.VehicleId);
 
-        builder.HasMany(v => v.Prospects)
-            .WithMany(p => p.Vehicles)
-            .UsingEntity<ProspectVehicle>(
-                j => j.HasOne(pv => pv.Prospect)
-                    .WithMany()
-                    .HasForeignKey(pv => pv.ProspectId)
-                    .OnDelete(DeleteBehavior.Cascade),
-                j => j.HasOne(pv => pv.Vehicle)
-                    .WithMany()
-                    .HasForeignKey(pv => pv.VehicleId)
-                    .OnDelete(DeleteBehavior.Cascade),
-                j =>
-                {
-                    j.HasKey(pv => new { pv.ProspectId, pv.VehicleId });
-                    j.ToTable("ProspectVehicle");
-                });
     }
 }

--- a/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
+++ b/frazer-api/src/Infrastructure/Persistence/Migrations/AppDbContextModelSnapshot.cs
@@ -233,7 +233,6 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
 
             b.ToTable("Prospects");
 
-            b.Navigation("Vehicles");
         });
 
         modelBuilder.Entity("FrazerDealer.Domain.Entities.RecurringJob", b =>
@@ -364,7 +363,7 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.ToTable("Vehicles");
         });
 
-        modelBuilder.Entity("FrazerDealer.Domain.Entities.ProspectVehicle", b =>
+        modelBuilder.Entity("ProspectVehicle", b =>
         {
             b.Property<Guid>("ProspectId")
                 .HasColumnType("uniqueidentifier");
@@ -452,13 +451,13 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.HasMany("FrazerDealer.Domain.Entities.Prospect", "Prospects")
                 .WithMany("Vehicles")
                 .UsingEntity(
-                    typeof(FrazerDealer.Domain.Entities.ProspectVehicle),
-                    r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
+                    "ProspectVehicle",
+                    r => r.HasOne("FrazerDealer.Domain.Entities.Prospect", null)
                         .WithMany()
                         .HasForeignKey("ProspectId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired(),
-                    l => l.HasOne("FrazerDealer.Domain.Entities.Vehicle", "Vehicle")
+                    l => l.HasOne("FrazerDealer.Domain.Entities.Vehicle", null)
                         .WithMany()
                         .HasForeignKey("VehicleId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -472,23 +471,19 @@ partial class AppDbContextModelSnapshot : ModelSnapshot
             b.Navigation("CurrentSale");
         });
 
-        modelBuilder.Entity("FrazerDealer.Domain.Entities.ProspectVehicle", b =>
+        modelBuilder.Entity("ProspectVehicle", b =>
         {
-            b.HasOne("FrazerDealer.Domain.Entities.Prospect", "Prospect")
+            b.HasOne("FrazerDealer.Domain.Entities.Prospect", null)
                 .WithMany()
                 .HasForeignKey("ProspectId")
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
 
-            b.HasOne("FrazerDealer.Domain.Entities.Vehicle", "Vehicle")
+            b.HasOne("FrazerDealer.Domain.Entities.Vehicle", null)
                 .WithMany()
                 .HasForeignKey("VehicleId")
                 .OnDelete(DeleteBehavior.Cascade)
                 .IsRequired();
-
-            b.Navigation("Prospect");
-
-            b.Navigation("Vehicle");
         });
 
         modelBuilder.Entity("FrazerDealer.Domain.Entities.Customer", b =>


### PR DESCRIPTION
## Summary
- configure the prospect-to-vehicle many-to-many mapping using a shared-type join entity so it matches existing snapshot expectations
- update the model snapshot to remove the premature Vehicles navigation reference and align the join entity metadata with the shared-type configuration

## Testing
- dotnet ef migrations add TestMigration --project src/Infrastructure --startup-project src/Api


------
https://chatgpt.com/codex/tasks/task_b_68f2acb0c2688331be66be94da11d9f0