### PR TITLE
Enable Swagger UI on API launch

### DIFF
--- a/frazer-api/src/Api/Properties/launchSettings.json
+++ b/frazer-api/src/Api/Properties/launchSettings.json
@@ -4,7 +4,8 @@
     "Api": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
## Summary
- enable the browser to open automatically to the Swagger UI when launching the API project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f2d00b07f483319c19d847c0ff5693