### PR TITLE
Fix Swagger UI route prefix

### DIFF
--- a/frazer-api/src/Api/Program.cs
+++ b/frazer-api/src/Api/Program.cs
@@ -121,7 +121,6 @@ app.UseSwagger();
 app.UseSwaggerUI(options =>
 {
     options.SwaggerEndpoint("/swagger/v1/swagger.json", "FrazerDealer API v1");
-    options.RoutePrefix = string.Empty;
 });
 
 app.UseSerilogRequestLogging();


### PR DESCRIPTION
## Summary
- remove the Swagger UI route prefix override so the UI is hosted under /swagger
- keep the generated OpenAPI document available at /swagger/v1/swagger.json

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68f2d3063e548331a8197a0f142934be