### PR TITLE
Add photo upload to inventory cards

### DIFF
--- a/frazer-ui/src/app/inventory/inventory.page.html
+++ b/frazer-ui/src/app/inventory/inventory.page.html
@@ -25,10 +25,32 @@
       <ion-label>
         <h2>{{ vehicle.stockNumber }} — {{ vehicle.year }} {{ vehicle.make }} {{ vehicle.model }}</h2>
         <p>VIN {{ vehicle.vin }} • Status: {{ vehicle.isSold ? 'Sold' : 'Available' }}</p>
+        <div
+          class="photo-gallery"
+          *ngIf="uploadedPhotos[vehicle.stockNumber]?.length as photos"
+          aria-label="Uploaded photos"
+        >
+          <ion-img
+            *ngFor="let photo of photos; index as photoIndex"
+            [src]="photo"
+            [alt]="'Uploaded photo ' + (photoIndex + 1) + ' for ' + vehicle.stockNumber"
+          ></ion-img>
+        </div>
       </ion-label>
       <ion-buttons slot="end">
         <ion-button fill="clear">View</ion-button>
         <ion-button fill="outline" color="success">Start Sale</ion-button>
+        <input
+          #fileInput
+          class="sr-only"
+          type="file"
+          accept="image/*"
+          multiple
+          (change)="onPhotosSelected(vehicle.stockNumber, $event)"
+        />
+        <ion-button fill="outline" type="button" (click)="fileInput.click()">
+          Add Photos
+        </ion-button>
       </ion-buttons>
     </ion-item>
   </ion-list>

--- a/frazer-ui/src/app/inventory/inventory.page.scss
+++ b/frazer-ui/src/app/inventory/inventory.page.scss
@@ -14,3 +14,29 @@ ion-thumbnail {
     border-radius: 8px;
   }
 }
+
+.photo-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+
+  ion-img {
+    width: 72px;
+    height: 72px;
+    border-radius: 8px;
+    object-fit: cover;
+    border: 1px solid var(--ion-color-light-shade);
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/frazer-ui/src/app/inventory/inventory.page.ts
+++ b/frazer-ui/src/app/inventory/inventory.page.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgFor } from '@angular/common';
+import { AsyncPipe, NgFor, NgIf } from '@angular/common';
 import { Component } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import {
@@ -46,6 +46,7 @@ import { VehicleSummary } from '../shared/models';
     ReactiveFormsModule,
     AsyncPipe,
     NgFor,
+    NgIf,
   ],
   templateUrl: './inventory.page.html',
   styleUrls: ['./inventory.page.scss'],
@@ -58,12 +59,32 @@ export class InventoryPage {
 
   readonly vehicles$ = this.fixtures.vehicles$;
 
+  uploadedPhotos: Record<string, string[]> = {};
+
   readonly filtered$ = combineLatest([
     this.vehicles$,
     this.search.valueChanges.pipe(startWith(this.search.value)),
   ]).pipe(
     map(([vehicles, term]) => this.filterVehicles(vehicles, term))
   );
+
+  async onPhotosSelected(stockNumber: string, event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) {
+      return;
+    }
+
+    const files = Array.from(input.files);
+    const photos = await Promise.all(files.map((file) => this.readFileAsDataUrl(file)));
+
+    const existing = this.uploadedPhotos[stockNumber] ?? [];
+    this.uploadedPhotos = {
+      ...this.uploadedPhotos,
+      [stockNumber]: [...existing, ...photos],
+    };
+
+    input.value = '';
+  }
 
   private filterVehicles(vehicles: VehicleSummary[], term: string): VehicleSummary[] {
     const value = term?.toLowerCase() ?? '';
@@ -77,5 +98,14 @@ export class InventoryPage {
         .toLowerCase()
         .includes(value)
     );
+  }
+
+  private readFileAsDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = (error) => reject(error);
+      reader.readAsDataURL(file);
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add an Add Photos action to each inventory vehicle card
- store uploaded image previews per vehicle and show them below the card details
- style the inline gallery and hide the native file input while keeping it accessible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fc10cc6c4c83318e7a23baa9655284