### PR TITLE
Fix inventory photo gallery binding and remove unused Angular imports

### DIFF
--- a/frazer-ui/src/app/inventory/inventory.page.html
+++ b/frazer-ui/src/app/inventory/inventory.page.html
@@ -25,17 +25,15 @@
       <ion-label>
         <h2>{{ vehicle.stockNumber }} — {{ vehicle.year }} {{ vehicle.make }} {{ vehicle.model }}</h2>
         <p>VIN {{ vehicle.vin }} • Status: {{ vehicle.isSold ? 'Sold' : 'Available' }}</p>
-        <div
-          class="photo-gallery"
-          *ngIf="uploadedPhotos[vehicle.stockNumber]?.length as photos"
-          aria-label="Uploaded photos"
-        >
-          <ion-img
-            *ngFor="let photo of photos; index as photoIndex"
-            [src]="photo"
-            [alt]="'Uploaded photo ' + (photoIndex + 1) + ' for ' + vehicle.stockNumber"
-          ></ion-img>
-        </div>
+        <ng-container *ngIf="uploadedPhotos[vehicle.stockNumber] as photos">
+          <div class="photo-gallery" *ngIf="photos.length" aria-label="Uploaded photos">
+            <ion-img
+              *ngFor="let photo of photos; index as photoIndex"
+              [src]="photo"
+              [alt]="'Uploaded photo ' + (photoIndex + 1) + ' for ' + vehicle.stockNumber"
+            ></ion-img>
+          </div>
+        </ng-container>
       </ion-label>
       <ion-buttons slot="end">
         <ion-button fill="clear">View</ion-button>

--- a/frazer-ui/src/app/sales/sales.detail.page.ts
+++ b/frazer-ui/src/app/sales/sales.detail.page.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, CurrencyPipe, DatePipe, NgFor, NgIf } from '@angular/common';
+import { AsyncPipe, CurrencyPipe, DatePipe, NgIf } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import {
@@ -40,7 +40,6 @@ import { provideFixtures } from '../data/fixtures';
     IonLabel,
     AsyncPipe,
     NgIf,
-    NgFor,
     DatePipe,
     CurrencyPipe,
   ],

--- a/frazer-ui/src/app/sales/sales.list.page.ts
+++ b/frazer-ui/src/app/sales/sales.list.page.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, CurrencyPipe, DatePipe, NgFor } from '@angular/common';
+import { AsyncPipe, DatePipe, NgFor } from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import {
@@ -37,7 +37,6 @@ import { provideFixtures } from '../data/fixtures';
     AsyncPipe,
     NgFor,
     DatePipe,
-    CurrencyPipe,
   ],
   templateUrl: './sales.list.page.html',
   styleUrls: ['./sales.page.scss'],

--- a/frazer-ui/src/app/shell/main-layout.component.ts
+++ b/frazer-ui/src/app/shell/main-layout.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, NgFor, NgIf } from '@angular/common';
+import { NgFor } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import {
   IonApp,
@@ -65,8 +65,6 @@ interface NavItem {
     RouterLinkActive,
     RouterOutlet,
     NgFor,
-    NgIf,
-    AsyncPipe,
   ],
   templateUrl: './main-layout.component.html',
   styleUrls: ['./main-layout.component.scss'],


### PR DESCRIPTION
## Summary
- fix the inventory photo gallery binding to expose the uploaded photo list correctly and avoid template errors
- remove unused Angular standalone imports that triggered compiler warnings in sales and shell components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68fc13dce9b08331bbd31c78f576f679